### PR TITLE
Add pipeline for site publication

### DIFF
--- a/.space.kts
+++ b/.space.kts
@@ -1,0 +1,26 @@
+job("Generate and publish sites") {
+    container("Generate public site", "openjdk:11") {
+        shellScript {
+            interpreter = "/bin/bash"
+            content = """
+                ./generate-public-site.sh
+                cp -r site $mountDir/share
+            """.trimIndent()
+        }
+    }
+
+    container("Publish public site", "openjdk:11") {
+        kotlinScript { api ->
+            val siteSource = "$mountDir/share/site/public"
+            val sourceDir = java.io.File(siteSource)
+            if (!sourceDir.isDirectory || sourceDir.list().isEmpty()) {
+                error("Directory $siteSource is empty")
+            }
+            api.space().experimentalApi.hosting.publishSite(
+                siteSource,
+                "topic-vis-demo-public",
+                HostingSiteSettings(public = true)
+            )
+        }
+    }
+}

--- a/generate-public-site.sh
+++ b/generate-public-site.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 mkdir -p site/public
-echo "Public topic visualization demo" >> site/public/index.html  
+echo "Public topic visualization demo" > site/public/index.html  

--- a/generate-public-site.sh
+++ b/generate-public-site.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+mkdir -p site/public
+echo "Public topic visualization demo" >> site/public/index.html  


### PR DESCRIPTION
This PR introduces an automation job that runs the (so far dummy) site generation script and publishes the results on https://topic-vis-demo-public.topvis.pages.jetbrains.team/. Currently the script is run on every commit. 

Please note that only public repositories should be processed with this script, as the resulting site is public.